### PR TITLE
(maint) Fix spec tests on Windows

### DIFF
--- a/spec/classes/create_multiple_ini_settings_spec.rb
+++ b/spec/classes/create_multiple_ini_settings_spec.rb
@@ -1,5 +1,24 @@
 require 'spec_helper'
 
 describe 'create_multiple_ini_settings' do
-  it { is_expected.to compile }
+  context 'on a non-Windows platform', if: !Puppet.features.microsoft_windows? do
+    let(:facts) do
+      { 'os' => { 'family'  => 'RedHat',
+                  'release' => { 'major' => '7',
+                                 'minor' => '1',
+                                 'full'  => '7.1.1503' } } }
+    end
+
+    it { is_expected.to compile }
+  end
+
+  context 'on a Windows platform', if: Puppet.features.microsoft_windows? do
+    let(:facts) do
+      { 'os' => { 'family'  => 'windows',
+                  'release' => { 'major' => '10',
+                                 'full'  => '10' } } }
+    end
+
+    it { is_expected.to compile }
+  end
 end

--- a/spec/fixtures/create_multiple_ini_settings/manifests/init.pp
+++ b/spec/fixtures/create_multiple_ini_settings/manifests/init.pp
@@ -1,16 +1,20 @@
-# Manifest creating multiplr ini_settings
+# Manifest creating multiple ini_settings
 class create_multiple_ini_settings {
+  if $facts['os']['family'] == 'windows' {
+    $defaults = { 'path' => 'C:/tmp/foo.ini' }
+  } else {
+    $defaults = { 'path' => '/tmp/foo.ini' }
+  }
 
-$defaults = { 'path' => '/tmp/foo.ini' }
-$example = {
-  'section1' => {
-    'setting1'  => 'value1',
-    'settings2' => {
-      'ensure' => 'absent'
+  $example = {
+    'section1' => {
+      'setting1'  => 'value1',
+      'settings2' => {
+        'ensure' => 'absent'
+      }
     }
   }
-}
-create_ini_settings($example, $defaults)
 
+  create_ini_settings($example, $defaults)
 }
 

--- a/spec/functions/create_ini_settings_spec.rb
+++ b/spec/functions/create_ini_settings_spec.rb
@@ -1,5 +1,3 @@
-#! /usr/bin/env ruby # rubocop:disable Lint/ScriptPermission : Rubocop error????
-
 require 'spec_helper'
 require 'rspec-puppet'
 

--- a/spec/unit/puppet/type/ini_setting_spec.rb
+++ b/spec/unit/puppet/type/ini_setting_spec.rb
@@ -1,4 +1,3 @@
-#! /usr/bin/env ruby # rubocop:disable Lint/ScriptPermission : Rubocop error?
 require 'spec_helper'
 
 ini_setting = Puppet::Type.type(:ini_setting)

--- a/spec/unit/puppet/type/ini_subetting_spec.rb
+++ b/spec/unit/puppet/type/ini_subetting_spec.rb
@@ -1,4 +1,3 @@
-#! /usr/bin/env ruby # rubocop:disable Lint/ScriptPermission : Rubocop error?
 require 'spec_helper'
 
 ini_subsetting = Puppet::Type.type(:ini_subsetting)


### PR DESCRIPTION
Previously the spec tests were failing on Windows due to linux paths being used
on a Windows platform.  This commit branches the test to use a correct absolute
path depending on the type of platform that's actually running the test.  This
is required as some functions within Puppet cannot be mocked correctly, such
as path validation.